### PR TITLE
Fix the install error for setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN gem install wpscan
 # Python install
 ENV PYTHONUNBUFFERED=1
 RUN apk add --no-cache python3
+RUN apk add --no-cache py3-setuptools
 
 # Setup user and group if specified
 ARG USER_ID


### PR DESCRIPTION
The command 
`docker image build -t wpwatcher .`

Produces the following output

` > [11/14] RUN python3 ./setup.py install:
#15 0.251 Traceback (most recent call last):
#15 0.251   File "./setup.py", line 2, in <module>
#15 0.251     from setuptools import setup, find_packages
#15 0.251 ModuleNotFoundError: No module named 'setuptools'`

The error could be fixed by adding the package py3-setuptools in the Dockerfile

